### PR TITLE
Fix syntax issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ associations.
 ## Installation
 Add this line to your application's Gemfile:
 
-````
+```
 gem "external_fields"
 ```
 


### PR DESCRIPTION
An extra ` was messing up the code formatting