### PR TITLE
Update Rubocop dev dependency for CVE-2017-8418

### DIFF
--- a/external_fields.gemspec
+++ b/external_fields.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "overcommit", "~> 0.23"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "rspec-rails", "~> 3.2"
-  spec.add_development_dependency "rubocop", "~> 0.29"
+  spec.add_development_dependency "rubocop", "~> 0.49"
   spec.add_development_dependency "rubocop-rspec-focused", "~> 0.0"
   spec.add_development_dependency "temping", "~> 3.2"
   spec.add_development_dependency "sqlite3", "~> 1.3"


### PR DESCRIPTION
Just trying to remove the big scary warning on the repo homepage.